### PR TITLE
Correction de l'affichage des projets par date

### DIFF
--- a/src/app/general-components/list-document-tile/list-document-tile.component.ts
+++ b/src/app/general-components/list-document-tile/list-document-tile.component.ts
@@ -28,7 +28,12 @@ export class ListDocumentTileComponent {
 
   getDateString() {
     let date = new Date(this.documentAndAuthor.document.date);
-    return date.toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
+    if (this.documentAndAuthor.document.type === DocumentType.project) {
+      return date.toLocaleDateString('fr-FR', { year: 'numeric', month: 'long' });
+    } else {
+      return date.toLocaleDateString('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
+    }
+    
   }
 
   

--- a/src/app/interaction-backend/resolver/document.resolver.ts
+++ b/src/app/interaction-backend/resolver/document.resolver.ts
@@ -26,7 +26,7 @@ const createDocumentResolver = (documentType: DocumentType, nbr? : number): Reso
         username.push(route.paramMap.get('username')!);
     }
 
-        return inject(DocumentService).getDocument(documentType = documentType, [], "", "", slug, [], SortingBy.dateAsc, username, nbr = nbr, false);
+        return inject(DocumentService).getDocument(documentType = documentType, [], "", "", slug, [], SortingBy.dateDesc, username, nbr = nbr, false);
     };
 };
 


### PR DESCRIPTION
Les projets sur la page de membre s'affichent par date descendant (close #39).
Les projets ne comprennent plus le jour dans la date de réalisation.