### PR TITLE
Proposition d'update du header : padding horizontal & ordre des éléments

### DIFF
--- a/src/app/general-components/header/header.component.css
+++ b/src/app/general-components/header/header.component.css
@@ -22,7 +22,7 @@ div#header {
 
 div#header-content {
     width: 100%;
-    padding: 40px 20px;
+    padding: 40px 3%;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/src/app/general-components/header/header.component.html
+++ b/src/app/general-components/header/header.component.html
@@ -6,6 +6,7 @@
         </a>
 
         <div id="nav-links" class="closed">
+            <a routerLink="project">Projets</a>
             <div class="dropdown-menu closed">
                 <a tabindex=0 onclick="toggleDropdownMenu(this);">Articles <i class="fa-solid fa-caret-down"></i></a>
                 <div>
@@ -14,9 +15,10 @@
                     <a routerLink="tips">Astuces</a>
                 </div>
             </div>
-            <a href="https://hebergos.insash.org" target="_blank">HebergOS</a>
-            <a routerLink="project">Projets</a>
             <a routerLink="les-membres">Les membres</a>
+            <a href="https://hebergos.insash.org" target="_blank">HebergOS</a>
+            
+            
 
         </div>
         <!-- <div id="calendar" onclick="getDay();">


### PR DESCRIPTION
**Proposition** d'update mineure du style du header
- Le padding horizontal (entre le logo et le bord, idem à droite) est un peu augmenté (20px -> 3%) car ça "collait trop" aux bords de l'écran
- Ordre des éléments changé ("Projet, ARticles, Membres, Hebergeos" à la place de "Article, Hebergos, Projets, Membre" pour mettre l'accent sur les projets du club 